### PR TITLE
Module migrated to 1.12.1 torch version

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,11 +15,7 @@ This [tutorial](http://pytorch.org/tutorials/advanced/cpp_extension.html) was us
 
 # Requirements
 
-This module is expected to compile for Pytorch `1.0.1`, on `Python > 3.5`.
-
-[UPDATE]
-
-Tested and compiled on Pytorch `1.12.1`, CUDA `11.6`.
+This module is expected to compile on Pytorch >= `1.11.0` (tested on `1.12.1`, CUDA `11.6`),  `Python > 3.5`
 
 # Usage direct projection
 
@@ -71,4 +67,4 @@ By using these coordinates, inverse warp will try to reconstruct `I1` with pixel
 As you can see, while the inverse warp shows duplication artefacts, the direct Warp shows Nan values where no colorization was done.
 The main interest of this direct warp here is to warp and warp back the depth in its original coordinate system. That way, you can see that occluded values are now considered NaNs.
 
-A more in depth study of this occlusion module is avalaible at this address : hhttps://github.com/ClementPinard/thesis-notebooks
+A more in depth study of this occlusion module is avalaible at this address : https://github.com/ClementPinard/thesis-notebooks

--- a/README.md
+++ b/README.md
@@ -17,6 +17,10 @@ This [tutorial](http://pytorch.org/tutorials/advanced/cpp_extension.html) was us
 
 This module is expected to compile for Pytorch `1.0.1`, on `Python > 3.5`.
 
+[UPDATE]
+
+Tested and compiled on Pytorch `1.12.1`, CUDA `11.6`.
+
 # Usage direct projection
 
 `from pytorch_direct_warp.direct_proj import direct_projection`

--- a/Warp_Module/direct_warp/direct_warper.py
+++ b/Warp_Module/direct_warp/direct_warper.py
@@ -5,6 +5,17 @@ from pytorch_direct_warp.direct_proj import direct_projection
 
 
 class DirectWarper(nn.Module):
+    """Apply direct projection from a list of square 3D points, with optional corresponding color.
+    Args:
+        points : List of 3D points with radius R. Size should be BxNx4.
+        colors : List of corresponding colors. Size should BxCxN.
+        pose : rototranslation matrix to multiply the points with before projecting Bx3X4
+        frame_matrix : K intrinsic matrix for projection Bx3X3.
+
+    Returns:
+        depth_map : corresponding depth BxHxW
+        color_map : BxCxHxW
+    """
     def __init__(self, keep_index=False):
         super(DirectWarper, self).__init__()
         self.id_grid = None

--- a/Warp_Module/proj_interface.cpp
+++ b/Warp_Module/proj_interface.cpp
@@ -43,7 +43,7 @@ at::Tensor proj_img_cpp_backward(
 
 // C++ interface
 
-#define CHECK_CUDA(x) AT_CHECK(x.type().is_cuda(), #x, " must be a CUDA tensor")
+#define CHECK_CUDA(x) TORCH_CHECK(x.type().is_cuda(), #x, " must be a CUDA tensor")
 
 std::vector<at::Tensor> proj_img_forward(
     at::Tensor points,


### PR DESCRIPTION
Hi, I just needed to use the module therefore i updated the code to be able to use it.
Following https://dev-discuss.pytorch.org/t/pytorch-1-11-dev-release-notes/588 some pieces resulted broken primary due to the drop of TH logic and `torch.autogra.Function` change

ref. https://github.com/pytorch/pytorch/wiki/TH-to-ATen-porting-guide